### PR TITLE
ci: remove libseccomp-dev installation for nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,11 +57,6 @@ jobs:
             crossbuild-essential-s390x \
             crossbuild-essential-ppc64el \
             crossbuild-essential-riscv64 \
-            libseccomp-dev:amd64 \
-            libseccomp-dev:arm64 \
-            libseccomp-dev:s390x \
-            libseccomp-dev:ppc64el \
-            libseccomp-dev:riscv64 \
             libbtrfs-dev:amd64 \
             libbtrfs-dev:arm64 \
             libbtrfs-dev:s390x \


### PR DESCRIPTION
since libseccomp is required only for building runc and we are only building containerd binaries in nightly, the libseccomp-dev dependency is removed. Foreign arch repositories are now removed since crossbuild-essential-* packages are {arm64, ppc64el,..} cross compiler packages for amd64 and arch specific repositories are not required.


(cherry picked from commit a9cb6090e2a2abe2b8625c60e4dee499e9291fb3)