### PR TITLE
Prepare release notes for v1.6.24

### DIFF
--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -352,7 +352,7 @@ func setLogLevel(context *cli.Context, config *srvconfig.Config) error {
 }
 
 func setLogFormat(config *srvconfig.Config) error {
-	f := config.Debug.Format
+	f := log.OutputFormat(config.Debug.Format)
 	if f == "" {
 		f = log.TextFormat
 	}

--- a/log/context.go
+++ b/log/context.go
@@ -44,6 +44,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// G is a shorthand for [GetLogger].
+//
+// We may want to define this locally to a package to get package tagged log
+// messages.
+var G = GetLogger
+
 // L is an alias for the standard logger.
 var L = &Entry{
 	Logger: logrus.StandardLogger(),
@@ -169,11 +175,6 @@ func WithLogger(ctx context.Context, logger *Entry) context.Context {
 // GetLogger retrieves the current logger from the context. If no logger is
 // available, the default logger is returned.
 func GetLogger(ctx context.Context) *Entry {
-	return G(ctx)
-}
-
-// G is a shorthand for [GetLogger].
-func G(ctx context.Context) *Entry {
 	if logger := ctx.Value(loggerKey{}); logger != nil {
 		return logger.(*Entry)
 	}

--- a/log/context.go
+++ b/log/context.go
@@ -29,7 +29,7 @@ var L = logrus.NewEntry(logrus.StandardLogger())
 type loggerKey struct{}
 
 // Fields type to pass to "WithFields".
-type Fields = logrus.Fields
+type Fields = map[string]any
 
 // Entry is a logging entry. It contains all the fields passed with
 // [Entry.WithFields]. It's finally logged when Trace, Debug, Info, Warn,

--- a/log/context.go
+++ b/log/context.go
@@ -14,6 +14,27 @@
    limitations under the License.
 */
 
+// Package log provides types and functions related to logging, passing
+// loggers through a context, and attaching context to the logger.
+//
+// # Transitional types
+//
+// This package contains various types that are aliases for types in [logrus].
+// These aliases are intended for transitioning away from hard-coding logrus
+// as logging implementation. Consumers of this package are encouraged to use
+// the type-aliases from this package instead of directly using their logrus
+// equivalent.
+//
+// The intent is to replace these aliases with locally defined types and
+// interfaces once all consumers are no longer directly importing logrus
+// types.
+//
+// IMPORTANT: due to the transitional purpose of this package, it is not
+// guaranteed for the full logrus API to be provided in the future. As
+// outlined, these aliases are provided as a step to transition away from
+// a specific implementation which, as a result, exposes the full logrus API.
+// While no decisions have been made on the ultimate design and interface
+// provided by this package, we do not expect carrying "less common" features.
 package log
 
 import (

--- a/log/context.go
+++ b/log/context.go
@@ -89,15 +89,15 @@ func SetFormat(format string) error {
 			TimestampFormat: RFC3339NanoFixed,
 			FullTimestamp:   true,
 		})
+		return nil
 	case JSONFormat:
 		logrus.SetFormatter(&logrus.JSONFormatter{
 			TimestampFormat: RFC3339NanoFixed,
 		})
+		return nil
 	default:
 		return fmt.Errorf("unknown log format: %s", format)
 	}
-
-	return nil
 }
 
 // WithLogger returns a new context with the provided logger. Use in

--- a/log/context.go
+++ b/log/context.go
@@ -45,7 +45,11 @@ import (
 )
 
 // L is an alias for the standard logger.
-var L = logrus.NewEntry(logrus.StandardLogger())
+var L = &Entry{
+	Logger: logrus.StandardLogger(),
+	// Default is three fields plus a little extra room.
+	Data: make(Fields, 6),
+}
 
 type loggerKey struct{}
 
@@ -116,13 +120,13 @@ func SetLevel(level string) error {
 		return err
 	}
 
-	logrus.SetLevel(lvl)
+	L.Logger.SetLevel(lvl)
 	return nil
 }
 
 // GetLevel returns the current log level.
 func GetLevel() Level {
-	return logrus.GetLevel()
+	return L.Logger.GetLevel()
 }
 
 // OutputFormat specifies a log output format.
@@ -141,13 +145,13 @@ const (
 func SetFormat(format OutputFormat) error {
 	switch format {
 	case TextFormat:
-		logrus.SetFormatter(&logrus.TextFormatter{
+		L.Logger.SetFormatter(&logrus.TextFormatter{
 			TimestampFormat: RFC3339NanoFixed,
 			FullTimestamp:   true,
 		})
 		return nil
 	case JSONFormat:
-		logrus.SetFormatter(&logrus.JSONFormatter{
+		L.Logger.SetFormatter(&logrus.JSONFormatter{
 			TimestampFormat: RFC3339NanoFixed,
 		})
 		return nil

--- a/log/context.go
+++ b/log/context.go
@@ -60,6 +60,21 @@ const (
 	// InfoLevel level. General operational entries about what's going on
 	// inside the application.
 	InfoLevel Level = logrus.InfoLevel
+
+	// WarnLevel level. Non-critical entries that deserve eyes.
+	WarnLevel Level = logrus.WarnLevel
+
+	// ErrorLevel level. Logs errors that should definitely be noted.
+	// Commonly used for hooks to send errors to an error tracking service.
+	ErrorLevel Level = logrus.ErrorLevel
+
+	// FatalLevel level. Logs and then calls "logger.Exit(1)". It exits
+	// even if the logging level is set to Panic.
+	FatalLevel Level = logrus.FatalLevel
+
+	// PanicLevel level. This is the highest level of severity. Logs and
+	// then calls panic with the message passed to Debug, Info, ...
+	PanicLevel Level = logrus.PanicLevel
 )
 
 // SetLevel sets log level globally. It returns an error if the given
@@ -70,6 +85,10 @@ const (
 //   - "trace" ([TraceLevel])
 //   - "debug" ([DebugLevel])
 //   - "info" ([InfoLevel])
+//   - "warn" ([WarnLevel])
+//   - "error" ([ErrorLevel])
+//   - "fatal" ([FatalLevel])
+//   - "panic" ([PanicLevel])
 func SetLevel(level string) error {
 	lvl, err := logrus.ParseLevel(level)
 	if err != nil {

--- a/log/context.go
+++ b/log/context.go
@@ -34,38 +34,42 @@ var (
 	L = logrus.NewEntry(logrus.StandardLogger())
 )
 
-type (
-	loggerKey struct{}
+type loggerKey struct{}
 
-	// Fields type to pass to `WithFields`, alias from `logrus`.
-	Fields = logrus.Fields
+// Fields type to pass to "WithFields".
+type Fields = logrus.Fields
 
-	// Level is a logging level
-	Level = logrus.Level
-)
+// RFC3339NanoFixed is [time.RFC3339Nano] with nanoseconds padded using
+// zeros to ensure the formatted time is always the same number of
+// characters.
+const RFC3339NanoFixed = "2006-01-02T15:04:05.000000000Z07:00"
 
+// Level is a logging level.
+type Level = logrus.Level
+
+// Supported log levels.
 const (
-	// RFC3339NanoFixed is time.RFC3339Nano with nanoseconds padded using zeros to
-	// ensure the formatted time is always the same number of characters.
-	RFC3339NanoFixed = "2006-01-02T15:04:05.000000000Z07:00"
+	// TraceLevel level. Designates finer-grained informational events
+	// than [DebugLevel].
+	TraceLevel Level = logrus.TraceLevel
 
-	// TextFormat represents the text logging format
-	TextFormat = "text"
+	// DebugLevel level. Usually only enabled when debugging. Very verbose
+	// logging.
+	DebugLevel Level = logrus.DebugLevel
 
-	// JSONFormat represents the JSON logging format
-	JSONFormat = "json"
-
-	// TraceLevel level.
-	TraceLevel = logrus.TraceLevel
-
-	// DebugLevel level.
-	DebugLevel = logrus.DebugLevel
-
-	// InfoLevel level.
-	InfoLevel = logrus.InfoLevel
+	// InfoLevel level. General operational entries about what's going on
+	// inside the application.
+	InfoLevel Level = logrus.InfoLevel
 )
 
-// SetLevel sets log level globally.
+// SetLevel sets log level globally. It returns an error if the given
+// level is not supported.
+//
+// level can be one of:
+//
+//   - "trace" ([TraceLevel])
+//   - "debug" ([DebugLevel])
+//   - "info" ([InfoLevel])
 func SetLevel(level string) error {
 	lvl, err := logrus.ParseLevel(level)
 	if err != nil {
@@ -81,7 +85,16 @@ func GetLevel() Level {
 	return logrus.GetLevel()
 }
 
-// SetFormat sets log output format
+// Supported log output formats.
+const (
+	// TextFormat represents the text logging format.
+	TextFormat = "text"
+
+	// JSONFormat represents the JSON logging format.
+	JSONFormat = "json"
+)
+
+// SetFormat sets the log output format ([TextFormat] or [JSONFormat]).
 func SetFormat(format string) error {
 	switch format {
 	case TextFormat:

--- a/log/context.go
+++ b/log/context.go
@@ -96,17 +96,20 @@ func GetLevel() Level {
 	return logrus.GetLevel()
 }
 
+// OutputFormat specifies a log output format.
+type OutputFormat string
+
 // Supported log output formats.
 const (
 	// TextFormat represents the text logging format.
-	TextFormat = "text"
+	TextFormat OutputFormat = "text"
 
 	// JSONFormat represents the JSON logging format.
-	JSONFormat = "json"
+	JSONFormat OutputFormat = "json"
 )
 
 // SetFormat sets the log output format ([TextFormat] or [JSONFormat]).
-func SetFormat(format string) error {
+func SetFormat(format OutputFormat) error {
 	switch format {
 	case TextFormat:
 		logrus.SetFormatter(&logrus.TextFormatter{

--- a/log/context.go
+++ b/log/context.go
@@ -23,16 +23,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var (
-	// G is an alias for GetLogger.
-	//
-	// We may want to define this locally to a package to get package tagged log
-	// messages.
-	G = GetLogger
-
-	// L is an alias for the standard logger.
-	L = logrus.NewEntry(logrus.StandardLogger())
-)
+// L is an alias for the standard logger.
+var L = logrus.NewEntry(logrus.StandardLogger())
 
 type loggerKey struct{}
 
@@ -141,11 +133,13 @@ func WithLogger(ctx context.Context, logger *logrus.Entry) context.Context {
 // GetLogger retrieves the current logger from the context. If no logger is
 // available, the default logger is returned.
 func GetLogger(ctx context.Context) *logrus.Entry {
-	logger := ctx.Value(loggerKey{})
+	return G(ctx)
+}
 
-	if logger == nil {
-		return L.WithContext(ctx)
+// G is a shorthand for [GetLogger].
+func G(ctx context.Context) *logrus.Entry {
+	if logger := ctx.Value(loggerKey{}); logger != nil {
+		return logger.(*logrus.Entry)
 	}
-
-	return logger.(*logrus.Entry)
+	return L.WithContext(ctx)
 }

--- a/log/context.go
+++ b/log/context.go
@@ -31,6 +31,14 @@ type loggerKey struct{}
 // Fields type to pass to "WithFields".
 type Fields = logrus.Fields
 
+// Entry is a logging entry. It contains all the fields passed with
+// [Entry.WithFields]. It's finally logged when Trace, Debug, Info, Warn,
+// Error, Fatal or Panic is called on it. These objects can be reused and
+// passed around as much as you wish to avoid field duplication.
+//
+// Entry is a transitional type, and currently an alias for [logrus.Entry].
+type Entry = logrus.Entry
+
 // RFC3339NanoFixed is [time.RFC3339Nano] with nanoseconds padded using
 // zeros to ensure the formatted time is always the same number of
 // characters.
@@ -129,20 +137,20 @@ func SetFormat(format OutputFormat) error {
 
 // WithLogger returns a new context with the provided logger. Use in
 // combination with logger.WithField(s) for great effect.
-func WithLogger(ctx context.Context, logger *logrus.Entry) context.Context {
+func WithLogger(ctx context.Context, logger *Entry) context.Context {
 	return context.WithValue(ctx, loggerKey{}, logger.WithContext(ctx))
 }
 
 // GetLogger retrieves the current logger from the context. If no logger is
 // available, the default logger is returned.
-func GetLogger(ctx context.Context) *logrus.Entry {
+func GetLogger(ctx context.Context) *Entry {
 	return G(ctx)
 }
 
 // G is a shorthand for [GetLogger].
-func G(ctx context.Context) *logrus.Entry {
+func G(ctx context.Context) *Entry {
 	if logger := ctx.Value(loggerKey{}); logger != nil {
-		return logger.(*logrus.Entry)
+		return logger.(*Entry)
 	}
 	return L.WithContext(ctx)
 }

--- a/log/context.go
+++ b/log/context.go
@@ -103,8 +103,7 @@ func SetFormat(format string) error {
 // WithLogger returns a new context with the provided logger. Use in
 // combination with logger.WithField(s) for great effect.
 func WithLogger(ctx context.Context, logger *logrus.Entry) context.Context {
-	e := logger.WithContext(ctx)
-	return context.WithValue(ctx, loggerKey{}, e)
+	return context.WithValue(ctx, loggerKey{}, logger.WithContext(ctx))
 }
 
 // GetLogger retrieves the current logger from the context. If no logger is

--- a/log/context_test.go
+++ b/log/context_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"reflect"
 	"testing"
+
+	"github.com/sirupsen/logrus"
 )
 
 func TestLoggerContext(t *testing.T) {
@@ -33,5 +35,29 @@ func TestLoggerContext(t *testing.T) {
 	b := GetLogger(ctx)
 	if !reflect.DeepEqual(a, b) || a != b {
 		t.Errorf("should be the same: %+v, %+v", a, b)
+	}
+}
+
+func TestCompat(t *testing.T) {
+	expected := Fields{
+		"hello1": "world1",
+		"hello2": "world2",
+		"hello3": "world3",
+	}
+
+	l := G(context.TODO())
+	l = l.WithFields(logrus.Fields{"hello1": "world1"})
+	l = l.WithFields(Fields{"hello2": "world2"})
+	l = l.WithFields(map[string]any{"hello3": "world3"})
+	if !reflect.DeepEqual(Fields(l.Data), expected) {
+		t.Errorf("expected: (%[1]T) %+[1]v, got: (%[2]T) %+[2]v", expected, l.Data)
+	}
+
+	l2 := L
+	l2 = l2.WithFields(logrus.Fields{"hello1": "world1"})
+	l2 = l2.WithFields(Fields{"hello2": "world2"})
+	l2 = l2.WithFields(map[string]any{"hello3": "world3"})
+	if !reflect.DeepEqual(Fields(l2.Data), expected) {
+		t.Errorf("expected: (%[1]T) %+[1]v, got: (%[2]T) %+[2]v", expected, l2.Data)
 	}
 }

--- a/log/context_test.go
+++ b/log/context_test.go
@@ -18,15 +18,20 @@ package log
 
 import (
 	"context"
+	"reflect"
 	"testing"
-
-	"gotest.tools/v3/assert"
 )
 
 func TestLoggerContext(t *testing.T) {
+	const expected = "one"
 	ctx := context.Background()
-
-	ctx = WithLogger(ctx, G(ctx).WithField("test", "one"))
-	assert.Equal(t, GetLogger(ctx).Data["test"], "one")
-	assert.Equal(t, G(ctx), GetLogger(ctx)) // these should be the same.
+	ctx = WithLogger(ctx, G(ctx).WithField("test", expected))
+	if actual := GetLogger(ctx).Data["test"]; actual != expected {
+		t.Errorf("expected: %v, got: %v", expected, actual)
+	}
+	a := G(ctx)
+	b := GetLogger(ctx)
+	if !reflect.DeepEqual(a, b) || a != b {
+		t.Errorf("should be the same: %+v, %+v", a, b)
+	}
 }

--- a/releases/v1.6.24.toml
+++ b/releases/v1.6.24.toml
@@ -1,0 +1,35 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.6.23"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The twenty-fourth patch release for containerd 1.6 contains various fixes and updates.
+
+### Notable Updates
+
+* **CRI: fix leaked shim caused by high IO pressure** ([#9004](https://github.com/containerd/containerd/pull/9004))
+* **Update to go1.20.8** ([#9073](https://github.com/containerd/containerd/pull/9073))
+* **Update runc to v1.1.9** ([#8966](https://github.com/containerd/containerd/pull/8966))
+* **Backport: add configurable mount options to overlay snapshotter** ([#8961](https://github.com/containerd/containerd/pull/8961))
+* **log: cleanups and improvements to decouple more from logrus** ([#9002](https://github.com/containerd/containerd/pull/9002))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.23+unknown"
+	Version = "1.6.24+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Welcome to the v1.6.24 release of containerd!

The twenty-fourth patch release for containerd 1.6 contains various fixes and updates.

### Notable Updates

* **CRI: fix leaked shim caused by high IO pressure** ([#9004](https://github.com/containerd/containerd/pull/9004))
* **Update to go1.20.8** ([#9073](https://github.com/containerd/containerd/pull/9073))
* **Update runc to v1.1.9** ([#8966](https://github.com/containerd/containerd/pull/8966))
* **Backport: add configurable mount options to overlay snapshotter** ([#8961](https://github.com/containerd/containerd/pull/8961))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Akihiro Suda
* Sebastiaan van Stijn
* Wei Fu
* Akhil Mohan
* Derek McGowan
* Cardy.Tang
* Danny Canter
* Kazuyoshi Kato
* Phil Estes
* Samuel Karp

### Changes
<details><summary>31 commits</summary>
<p>

  * [`f52025063`](https://github.com/containerd/containerd/commit/f52025063398c4d03bf49dedf8d8ea79483be465) Prepare release notes for v1.6.24
* [release/1.6] update to go1.20.8 ([#9073](https://github.com/containerd/containerd/pull/9073))
  * [`a2c294800`](https://github.com/containerd/containerd/commit/a2c294800ec11447b497bf7452bbbfba06c0168d) [release/1.6] update to go1.20.8
* [release/1.6 backport] make repositories of install dependencies configurable ([#9024](https://github.com/containerd/containerd/pull/9024))
  * [`0da8dcaa7`](https://github.com/containerd/containerd/commit/0da8dcaa7c93c0b708c375a32328a7b85fd668d8) make repositories of install dependencies configurable
* [release/1.6 backport] update Golang to go1.20.7, minimum version go1.19 ([#9020](https://github.com/containerd/containerd/pull/9020))
  * [`8e6a9de5b`](https://github.com/containerd/containerd/commit/8e6a9de5b5291b97684e948be096317611b37930) update to go1.20.7, go1.19.12
  * [`8b2eb371f`](https://github.com/containerd/containerd/commit/8b2eb371f958f1bfc5bcab5ee70bcad18b2e5efc) Update Go to 1.20.6,1.19.11
  * [`cff669c7a`](https://github.com/containerd/containerd/commit/cff669c7aab055d6b46bbb27fd044aba5e1453d8) update go to go1.20.5, go1.19.10
  * [`f34a22de9`](https://github.com/containerd/containerd/commit/f34a22de99b57e30cd33d3769e3765950475ba07) update go to go1.20.4, go1.19.9
  * [`e8e73065e`](https://github.com/containerd/containerd/commit/e8e73065ec668097067d37381399a80c8107fae1) update go to go1.20.3, go1.19.8
  * [`9b3f950d6`](https://github.com/containerd/containerd/commit/9b3f950d607c3a6c2a3c1b8740c87338a986e203) Go 1.20.2
  * [`17d03ac68`](https://github.com/containerd/containerd/commit/17d03ac681f61cd83c2bc7239956504c25ceb2f4) Go 1.20.1
  * [`861f65447`](https://github.com/containerd/containerd/commit/861f65447c4cc59b2b91e441b24f1c80a730ce2b) go.mod: go 1.19
  * [`81fa93784`](https://github.com/containerd/containerd/commit/81fa937842ac2501f777e23cddab8c7a573bd318) Stop using math/rand.Read and rand.Seed (deprecated in Go 1.20)
  * [`70dc11a6c`](https://github.com/containerd/containerd/commit/70dc11a6c1258891aa281815bb94d4bdc1194fe7) lint: remove `//nolint:dupword` that are no longer needed
  * [`fec784a06`](https://github.com/containerd/containerd/commit/fec784a06ad4276574dfb16ff631f9839f3b676c) lint: silence "SA1019: tar.TypeRegA has been deprecated... (staticheck)"
  * [`6648df1ad`](https://github.com/containerd/containerd/commit/6648df1ada2575df6adcaf295b611d966d3308d7) lint: silence "type `HostFileConfig` is unused (unused)"
  * [`e6b268bc7`](https://github.com/containerd/containerd/commit/e6b268bc703b5903de719533a8fbe0307767342c) golangci-lint v1.51.1
  * [`c552ccf67`](https://github.com/containerd/containerd/commit/c552ccf6769245e1531212505fa75e89f6f6ff1c) go.mod: golang.org/x/sync v0.1.0
* [releases/1.6] *: fix leaked shim caused by high IO pressure ([#9004](https://github.com/containerd/containerd/pull/9004))
  * [`d00af5c3e`](https://github.com/containerd/containerd/commit/d00af5c3ea1a290112b3a56bee31023ef1d2019d) integration: issue7496 case should work for runc.v2 only
  * [`583696e4e`](https://github.com/containerd/containerd/commit/583696e4e0b055b8a0f860b9ed7f31f0f3127ff4) Vagrantfile: add strace tool
  * [`ab21d60d2`](https://github.com/containerd/containerd/commit/ab21d60d27d1d7c87423e9b4ecb076358762e89b) pkg/cri/server: add criService as argument when handle exit event
  * [`a229883cb`](https://github.com/containerd/containerd/commit/a229883cb1bffecbd8bd4d41ab19c99110bbd189) pkg/cri/server: fix leaked shim issue
  * [`d8f824200`](https://github.com/containerd/containerd/commit/d8f824200cdc39410bf9a4d110073186d6864f64) integration: add case to reproduce #7496
* [release/1.6] Cherry-pick: [overlay] add configurable mount options to overlay snapshotter ([#8961](https://github.com/containerd/containerd/pull/8961))
  * [`8cd40e1d0`](https://github.com/containerd/containerd/commit/8cd40e1d0f13e5ddfef13833b265f6dfa298ec69) Add configurable mount options to overlay
  * [`453fa397a`](https://github.com/containerd/containerd/commit/453fa397a1f0f00871ff1ca4314b65e898e33661) feat: make overlay sync removal configurable
* [release/1.6 backport] update runc binary to v1.1.9 ([#8966](https://github.com/containerd/containerd/pull/8966))
  * [`4cb7764df`](https://github.com/containerd/containerd/commit/4cb7764df8025d0a6edb34f6b69daf6c2abe6ad0) update runc binary to v1.1.9
</p>
</details>

### Dependency Changes

* **golang.org/x/sync**  036812b2e83c -> v0.1.0

Previous release can be found at [v1.6.23](https://github.com/containerd/containerd/releases/tag/v1.6.23)